### PR TITLE
Update apt-dater-host-yum

### DIFF
--- a/files/apt-dater-host-yum
+++ b/files/apt-dater-host-yum
@@ -234,7 +234,7 @@ sub do_status() {
 }
 
 sub do_upgrade() {
-    system("$GETROOT yum update");
+    system("$GETROOT yum -y update");
 }
 
 sub do_install() {

--- a/understanding_puppet-apt_dater.md
+++ b/understanding_puppet-apt_dater.md
@@ -1,0 +1,24 @@
+# my apt-dater understanding
+
+```
+.
+├── files
+│   ├── apt-dater-host-yum
+│   └── empty
+├── Gemfile
+├── manifests
+│   ├── host_fragment.pp
+│   ├── host.pp
+│   ├── init.pp
+│   ├── manager.pp
+│   └── params.pp
+├── metadata.json
+├── README.md
+├── templates
+│   ├── apt-dater.conf.erb
+│   ├── apt-dater-screenrc.erb
+│   └── update-apt-dater-hosts.erb
+└── understanding_puppet-apt_dater.md
+```
+* files : static across all nodes
+* templates : ruby templates here, scripts wich are modified


### PR DESCRIPTION
for RedHat like distributions (REHL ; CentOS ; Scientific Linux ; Oracle Linux), it's very painfull to confirm each client update. So, I prefer to launch "yum -y update" instead of "yum update".
